### PR TITLE
Explicitly configure server addresses in clients; also includes a minimal usage example

### DIFF
--- a/assisipy/bee.py
+++ b/assisipy/bee.py
@@ -82,18 +82,24 @@ class Bee:
 
     :param string rtc_file_name: Name of the run-time-configuration (RTC) file. This file specifies the simulation connection parameters and the name of the simulated bee object.
     :param string name: The name of the bee (if not specified in the RTC file).
+    :param dict kwargs: accepts strings to override values for:
+        `pub_addr` (defaults to localhost:5556)
+        `sub_addr` (defautls to localhost:5555)
+
     """
     
-    def __init__(self, rtc_file_name='', name = 'Bee'):
+    def __init__(self, rtc_file_name='', name = 'Bee', **kwargs):
         
         
         if rtc_file_name:
             # Parse the rtc file
             raise NotImplementedError("RTC file parsing for Bees is not implemented yet. Please call the constructor with the name=beename argument.")
         else:
-            # Use default values
-            self.__pub_addr = 'tcp://127.0.0.1:5556'
-            self.__sub_addr = 'tcp://127.0.0.1:5555'
+            # parse any keywords provided, otherwise take default values
+            self.__pub_addr = kwargs.get('pub_addr', 'tcp://127.0.0.1:5556')
+            self.__sub_addr = kwargs.get('sub_addr', 'tcp://127.0.0.1:5555')
+            #self.__pub_addr = 'tcp://127.0.0.1:5556'
+            #self.__sub_addr = 'tcp://127.0.0.1:5555'
             self.__name = name
         
         self.__object_readings = dev_msgs_pb2.ObjectArray()

--- a/assisipy/sim.py
+++ b/assisipy/sim.py
@@ -22,14 +22,18 @@ class Control:
 
     """
 
-    def __init__(self, rtc_file_name=''):
+    def __init__(self, rtc_file_name='', **kwargs):
 
         if rtc_file_name:
             # Parse the rtc file
+            raise NotImplementedError(
+                "RTC file parsing for Simulator control is not implemented yet. "
+                "Please call the constructor with the name=beename argument.")
             pass
         else:
-            # Use default values
-            self.__pub_addr = 'tcp://127.0.0.1:5556'
+            # parse any keywords provided, otherwise take default values
+            self.__pub_addr = kwargs.get('pub_addr', 'tcp://127.0.0.1:5556')
+            #self.__pub_addr = 'tcp://127.0.0.1:5556'
             self.__context = zmq.Context(1)
             self.__pub = self.__context.socket(zmq.PUB)
             self.__pub.connect(self.__pub_addr)

--- a/examples/remote_server/Playground_N.cfg
+++ b/examples/remote_server/Playground_N.cfg
@@ -1,0 +1,25 @@
+#[Net]
+# generic, unsectioned?
+pub_addr = tcp://*:5155
+sub_addr = tcp://*:5156
+
+[Arena]
+radius = 20
+
+[Heat]
+env_temp = 23   # Environmantal temperature in C
+scale = 0.5     # Scale of the grid ?
+border_size = 0 # ?
+
+[Vibration]
+range = 10   # in cm
+maximum_amplitude = 8
+amplitude_quadratic_decay = 0
+noise = 0
+
+[Viewer]
+max_vibration = 10
+
+[Simulation]
+speedup_factor = 2.0
+timer_period = 0.1

--- a/examples/remote_server/Playground_S.cfg
+++ b/examples/remote_server/Playground_S.cfg
@@ -1,0 +1,27 @@
+#[Net]
+# generic, unsectioned?
+pub_addr = tcp://*:5255
+sub_addr = tcp://*:5256
+
+[Arena]
+radius = 20
+
+[Heat]
+env_temp = 23   # Environmantal temperature in C
+scale = 0.5     # Scale of the grid ?
+border_size = 0 # ?
+log_file = /tmp/s_arena_heat.log
+#log_file = s_arena_heat.log
+
+[Vibration]
+range = 10   # in cm
+maximum_amplitude = 8
+amplitude_quadratic_decay = 0
+noise = 0
+
+[Viewer]
+max_vibration = 10
+
+[Simulation]
+speedup_factor = 2.0
+timer_period = 0.1

--- a/examples/remote_server/README
+++ b/examples/remote_server/README
@@ -1,0 +1,16 @@
+# First, you need to launch the simulator environment
+# Here we assume that...
+#   the server IP address is 127.0.0.1; that 
+#   the server LISTENS on port 5156, meaning that the clients must PUBLISH to 5156
+#   the server EMITS from port 5155, meaning that clients must SUBSCRIBE to 5155
+# Then, to launch a bee and a CASU (only one directional):
+python spawn_eg.py -svr 127.0.0.1 -pp 5156
+
+# and to execute the bee behaviour:
+python bee_wander.py -bn bee-001 -pp 5156 -sp 5155
+
+# press <ctrl-c> to exit, and it should halt the bee in place.
+
+# no CASU behaviour is defined as yet.
+
+

--- a/examples/remote_server/README
+++ b/examples/remote_server/README
@@ -3,6 +3,16 @@
 #   the server IP address is 127.0.0.1; that 
 #   the server LISTENS on port 5156, meaning that the clients must PUBLISH to 5156
 #   the server EMITS from port 5155, meaning that clients must SUBSCRIBE to 5155
+# 
+# Note: to set this up, if you have at least rev 30de0b2 then you can use the config
+# file `Playground_N.cfg` to initialise the server appropriately:
+#
+cp ./Playground_N.cfg <playground_dir>
+cd <playground_dir>
+./assisi_playground -c Playground_N.cfg
+# alternatively, you can use the command-line options
+./assisi_playground --pub_addr tcp://*:5155 --sub_addr tcp://*5156
+
 # Then, to launch a bee and a CASU (only one directional):
 python spawn_eg.py -svr 127.0.0.1 -pp 5156
 

--- a/examples/remote_server/bee_wander.py
+++ b/examples/remote_server/bee_wander.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+A simple bee wander behavior, spawned in an arbitrary environment/simulator.
+
+The bee behaviour is taken directly from examples/wandering_bee.
+
+"""
+
+import argparse
+from assisipy import bee
+
+class BeeWander:
+    """
+    A demo bee controller.
+    An simple example of using the Bee-API.
+    """
+
+    def __init__(self, bee_name, pub_addr, sub_addr):
+        # note: this connection only works with the `config_agents` branch of
+        # RMM-FCUL fork
+        self.__bee = bee.Bee(name=bee_name, pub_addr=pub_addr, sub_addr=sub_addr)
+
+    def go_straight(self):
+        self.__bee.set_vel(0.5,0.5)
+
+    def stop(self):
+        self.__bee.set_vel(0.,0.)
+
+    def turn_left(self):
+        self.__bee.set_vel(-0.1,0.1)
+
+    def turn_right(self):
+        self.__bee.set_vel(0.1,-0.1)
+
+    def wander(self):
+        """
+        Wander around and avoid obstacles.
+        """
+        while True:
+            self.go_straight()
+            while ((self.__bee.get_range(bee.OBJECT_FRONT) < 3)
+                   and (self.__bee.get_range(bee.OBJECT_RIGHT_FRONT) < 4)):
+                self.turn_left()
+            while ((self.__bee.get_range(bee.OBJECT_FRONT) < 3)
+                   and (self.__bee.get_range(bee.OBJECT_LEFT_FRONT) < 4)):
+                self.turn_right()
+
+if __name__ == '__main__':
+    # process command-line args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-bn', '--bee-name', type=str, default='bee-001',
+                        help="name of the bee to attach to")
+    parser.add_argument('-svr', '--server-addr', type=str, default='127.0.0.1',
+                        help="the IP address of the enki server")
+    parser.add_argument('-pp', '--pub-port', type=str, default='5556',
+                        help="publish port (wherever the enki server listens for commands)")
+    parser.add_argument('-sp', '--sub-port', type=str, default='5555',
+                        help="subscribe port (wherever the enki server emits commands)")
+    args = parser.parse_args()
+
+
+    pub_addr = "tcp://{}:{}".format(args.server_addr, args.pub_port)
+    sub_addr = "tcp://{}:{}".format(args.server_addr, args.sub_port)
+    # Start the wander behavior.
+    # The name has to match the name of the spawned bee!
+    wanderer = BeeWander(bee_name=args.bee_name, pub_addr=pub_addr,
+                         sub_addr=sub_addr,)
+
+    # start behaviour, and handle keyboard interrupt gracefully
+    try:
+        wanderer.wander()
+    except KeyboardInterrupt:
+        print "shutting down bee {}".format(args.bee_name)
+
+    wanderer.stop()

--- a/examples/remote_server/spawn_eg.py
+++ b/examples/remote_server/spawn_eg.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+'''
+a simple simulation environment with one casu and one bee.
+
+the agents are spawned in a specifc environment/simulator, which can be a
+remote machine -- although this canonical example uses the IP address of
+`localhost`.
+
+
+'''
+
+import argparse
+from assisipy import sim
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-svr', '--server-addr', type=str, default='127.0.0.1',
+                        help="the IP address of the enki server")
+    parser.add_argument('-pp', '--pub-port', type=str, default='5556',
+                        help="publish port (wherever the enki server listens for commands)")
+    parser.add_argument('-sp', '--sub-port', type=str, default='5555',
+                        help="subscribe port (wherever the enki server emits commands)")
+    args = parser.parse_args()
+
+    pub_addr = "tcp://{}:{}".format(args.server_addr, args.pub_port)
+    sub_addr = "tcp://{}:{}".format(args.server_addr, args.sub_port)
+    print "[I] attempting to connect a controller handle to server @"
+    print "\t publish address =" + pub_addr
+    simctrl = sim.Control(pub_addr=pub_addr)
+
+    # spawn casu and bee into the simulator
+    # (type, name, coordinaets)
+    # coordinates: x,y,orientation(rad)
+    casu_name = 'casu-001'
+    bee_name  = 'bee-001'
+    simctrl.spawn('Casu', casu_name, (0,0,0))
+    print "[I] spawn of Casu '{}' requested".format(casu_name)
+    simctrl.spawn('Bee', bee_name, (3,5,0))
+    print "[I] spawn of Bee  '{}' requested".format(bee_name)
+
+


### PR DESCRIPTION
- Parameters for server publish & subscribe addresses passed into the client constructor using kwargs, with defaults that are as per the previous hard-coded values.
- note that the CASU client is unchanged since it already parses rtc configuration files to set up publish & subscribe addresses
- a basic example allows for testing
- assisi-playground configuration files included with example (not clear whether this repo is most appropriate location but it is part of the example at least)