### PR TITLE
Assisipy.Casu provides name, label, and data for received messages (label added)

### DIFF
--- a/assisipy/casu.py
+++ b/assisipy/casu.py
@@ -117,8 +117,8 @@ class Casu:
     The fully constructed object is returned only after
     the data connection has been established.
 
-    :param string rtc_file_name: Name of the run-time configuration (RTC) file. If no file is provided, the default configuration is used.
-    :param string name: Casu name (if a RTC file is provided, this value is overridden).
+    :param string rtc_file_name: Name of the run-time configuration (RTC) file. If no file is provided, the default configuration is used; if `name` is provided, this parameter is ignored (and no RTC file is read).
+    :param string name: Casu name (note: this value takes precedence over `rtc_file_name` if both provided: thus no RTC file is read)
     :param bool log: A variable indicating whether to log all incoming and outgoing data. If set to true, a logfile in the form 'YYYY-MM-DD-HH-MM-SS-name.csv' is created.
     """
 

--- a/assisipy/casu.py
+++ b/assisipy/casu.py
@@ -12,7 +12,7 @@ import yaml # For parsing configuration (.rtc) files
 
 # For logging
 from datetime import datetime
-import csv  
+import csv
 
 from msg import dev_msgs_pb2
 from msg import base_msgs_pb2
@@ -21,7 +21,7 @@ from msg import base_msgs_pb2
 
 """ IR range sensors """
 
-IR_N = 0 
+IR_N = 0
 """ Range sensor pointing to 0° (NORTH) """
 IR_NE = 1
 """ Range sensor pointing to 45° (NORTH-EAST) """
@@ -40,7 +40,7 @@ LIGHT_ACT = 6
 DLED_TOP = 7
 """ Top diagnostic LED """
 
-TEMP_N = 8 
+TEMP_N = 8
 """ Temperature sensor at 0° (NORTH) """
 TEMP_E = 9
 """ Temperature sensor at 90° (EAST) """
@@ -110,10 +110,10 @@ Special value to get all sensor values from an array of sensors
 """
 
 class Casu:
-    """ 
+    """
     The low-level interface to Casu devices.
 
-    Initializes the object and starts listening for data. 
+    Initializes the object and starts listening for data.
     The fully constructed object is returned only after
     the data connection has been established.
 
@@ -121,9 +121,9 @@ class Casu:
     :param string name: Casu name (if a RTC file is provided, this value is overridden).
     :param bool log: A variable indicating whether to log all incoming and outgoing data. If set to true, a logfile in the form 'YYYY-MM-DD-HH-MM-SS-name.csv' is created.
     """
-    
+
     def __init__(self, rtc_file_name='casu.rtc', name = '', log = False, log_folder = '.'):
-        
+
 
         if name:
             # Use default values
@@ -133,6 +133,7 @@ class Casu:
             self.__neighbors = None
             self.__msg_pub_addr = None
             self.__msg_sub = None
+            self.__phys_logi_map = {}
         else:
             # Parse the rtc file
             with open(rtc_file_name) as rtc_file:
@@ -184,27 +185,27 @@ class Casu:
             for direction in self.__neighbors:
                 self.__msg_sub.connect(self.__neighbors[direction]['address'])
             self.__msg_sub.setsockopt(zmq.SUBSCRIBE, self.__name)
-        
+
         # Connect the control publisher socket
         self.__pub = self.__context.socket(zmq.PUB)
         self.__pub.connect(self.__pub_addr)
-        
+
         # Connect to the device and start receiving data
         self.__comm_thread.start()
         # Wait for the connection
         while not self.__connected:
             time.sleep(1)
         print('{0} connected!'.format(self.__name))
-            
+
 
     def __update_readings(self):
-        """ 
-        Get data from Casu and update local data. 
+        """
+        Get data from Casu and update local data.
         """
         self.__sub = self.__context.socket(zmq.SUB)
         self.__sub.connect(self.__sub_addr)
         self.__sub.setsockopt(zmq.SUBSCRIBE, self.__name)
-        
+
         while not self.__stop:
             [name, dev, cmd, data] = self.__sub.recv_multipart()
             self.__connected = True
@@ -233,7 +234,7 @@ class Casu:
                     if self.__acc_readings.reading:
                         acc_freqs = [0, 0, 0, 0]
                         acc_amps = [0, 0, 0, 0]
-                    
+
                         for i in range(0, 4):
                             acc_freqs[i] = self.__acc_readings.reading[i].freq
                             acc_amps[i] = self.__acc_readings.reading[i].amplitude
@@ -255,7 +256,7 @@ class Casu:
                     print('Unknown command {0} for {1}'.format(cmd, self.__name))
             else:
                 print('Unknown device {0} for {1}'.format(dev, self.__name))
-            
+
             if self.__msg_sub:
                 try:
                     [name, msg, sender, data] = self.__msg_sub.recv_multipart(zmq.NOBLOCK)
@@ -270,7 +271,7 @@ class Casu:
         """
         Performs necessary cleanup operations, i.e. stops communication threads,
         closes connections and files.
-        """        
+        """
         # Wait for communicaton threads to finish
         self.__comm_thread.join()
 
@@ -312,11 +313,11 @@ class Casu:
         self.__write_to_log(["em_config", time.time(), mode])
 
     def get_range(self, id):
-        """ 
-        Returns the range reading (in cm) corresponding to sensor id. 
+        """
+        Returns the range reading (in cm) corresponding to sensor id.
 
         .. note::
-           
+
            This API call might become deprecated in favor of get_raw_value,
            to better reflect actual sensor capabilities.
         """
@@ -325,11 +326,11 @@ class Casu:
                 return self.__ir_range_readings.range[id]
             else:
                 return -1
-        
+
     def get_ir_raw_value(self, id):
-        """ 
-        Returns the raw value from the IR proximity sensor corresponding to sensor id. 
-        
+        """
+        Returns the raw value from the IR proximity sensor corresponding to sensor id.
+
         """
         with self.__lock:
             if self.__ir_range_readings.raw_value:
@@ -342,7 +343,7 @@ class Casu:
 
     def get_temp(self, id):
         """
-        Returns the temperature reading of sensor id. 
+        Returns the temperature reading of sensor id.
 
          """
         with self.__lock:
@@ -373,7 +374,7 @@ class Casu:
         self.__pub.send_multipart([self.__name, device, "temp",
                                    temp_msg.SerializeToString()])
         self.__write_to_log([device + "_temp", time.time(), temp])
- 
+
     def temp_standby(self, id = PELTIER_ACT):
         """
         Turn the temperature actuator off.
@@ -391,7 +392,7 @@ class Casu:
     def get_peltier_setpoint(self, id = PELTIER_ACT):
         """
         Get the temperature actuator setpoint and state.
-        
+
         :return: (temp,on) tuple, where temp is the temperature setpoint,
         and on is True if the actuator is switched on.
         """
@@ -449,10 +450,10 @@ class Casu:
     def set_vibration_freq(self, f, id = VIBE_ACT):
         """
         Sets the vibration frequency of the pwm motor.
-        
+
         :param float f: Vibration frequency, between 0 and 500 Hz.
         """
-        
+
         vibration = dev_msgs_pb2.VibrationSetpoint()
         vibration.freq = f
         vibration.amplitude = 0
@@ -471,7 +472,7 @@ class Casu:
         pass
 
     def get_vibration_amplitude(self, id):
-        """ 
+        """
         Returns the vibration amplitude reported by sensor id.
 
         .. note::
@@ -484,7 +485,7 @@ class Casu:
         """
         Turn the vibration actuator id off.
         """
-        
+
         vibration = dev_msgs_pb2.VibrationSetpoint()
         vibration.freq = 0
         vibration.amplitude = 0
@@ -526,7 +527,7 @@ class Casu:
         self.__write_to_log(["light_ref", time.time(), 0, 0, 0])
 
     def set_diagnostic_led_rgb(self, r = 0, g = 0, b = 0, id = DLED_TOP):
-        """ 
+        """
         Set the diagnostic LED light color. Automatically turns the actuator on.
 
         :param float r: Red component intensity, between 0 and 1.
@@ -543,20 +544,20 @@ class Casu:
         light.color.red = r
         light.color.green = g
         light.color.blue = b
-        self.__pub.send_multipart([self.__name, "DiagnosticLed", "On", 
+        self.__pub.send_multipart([self.__name, "DiagnosticLed", "On",
                                    light.SerializeToString()])
         self.__write_to_log(["dled_ref", time.time(), r, g, b])
 
     def get_diagnostic_led_rgb(self, id = DLED_TOP):
-        """ 
-        Get the diagnostic light RGB value. 
+        """
+        Get the diagnostic light RGB value.
 
         :return: An (r,g,b) tuple (values between 0 and 1).
         """
         pass
 
     def diagnostic_led_standby(self, id = DLED_TOP):
-        """ 
+        """
         Turn the diagnostic LED off.
         """
         light = base_msgs_pb2.ColorStamped();
@@ -573,16 +574,16 @@ class Casu:
         """
         success = False
         if direction in self.__neighbors:
-            self.__msg_pub.send_multipart([self.__neighbors[direction]['name'], 'Message', 
+            self.__msg_pub.send_multipart([self.__neighbors[direction]['name'], 'Message',
                                            self.__name, msg])
             success = True
-        
+
         return success
 
     def read_message(self):
         """
         Retrieve the latest message from the buffer.
-        
+
         Returns a dictionary with sender(string), and data (string) fields.
         """
         msg = []
@@ -590,11 +591,11 @@ class Casu:
             with self.__lock:
                 msg = self.__msg_queue.pop()
 
-                # attempt to find the label (logical name for neighbour) from 
-                # the records found in the RTC file (now part of the Casu 
+                # attempt to find the label (logical name for neighbour) from
+                # the records found in the RTC file (now part of the Casu
                 # instance)
                 msg['label'] = self.__phys_logi_map.get(msg['sender'], None)
-        
+
         return msg
 
     def __write_to_log(self, data):
@@ -608,26 +609,26 @@ class Casu:
         '''
         parse the RTC file for communication links and return as a map.
         '''
-        phys_logi_map = {} 
+        phys_logi_map = {}
 
-        try: 
-            deploy = yaml.safe_load(file(rtc, 'r')) 
-            if 'neighbors' in deploy and deploy['neighbors'] is not None: 
-                for k, v in deploy['neighbors'].iteritems(): 
-                    neigh = v.get('name', None) 
-                    if neigh: 
-                        phys_logi_map[neigh] = k 
-     
-        except IOError: 
-            print "[W] could not read rtc conf file {}".format(rtc) 
-         
-        return phys_logi_map 
+        try:
+            deploy = yaml.safe_load(file(rtc, 'r'))
+            if 'neighbors' in deploy and deploy['neighbors'] is not None:
+                for k, v in deploy['neighbors'].iteritems():
+                    neigh = v.get('name', None)
+                    if neigh:
+                        phys_logi_map[neigh] = k
+
+        except IOError:
+            print "[W] could not read rtc conf file {}".format(rtc)
+
+        return phys_logi_map
 
 
 
 
 if __name__ == '__main__':
-    
+
     casu1 = Casu()
     switch = -1
     count = 0

--- a/examples/messaging/casu-01-02/north.py
+++ b/examples/messaging/casu-01-02/north.py
@@ -18,7 +18,7 @@ class CasuController:
         msg = self.__casu.read_message()
         if msg:
             if  msg['data'] == 'On':
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
             else:
                 self.__casu.diagnostic_led_standby(casu.DLED_TOP)
             

--- a/examples/messaging/casu-02-02/center.py
+++ b/examples/messaging/casu-02-02/center.py
@@ -19,21 +19,21 @@ class CasuController:
         """
         while True:
             if self.__casu.get_range(casu.IR_N) < 2:
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
                 self.old_state = self.state
                 self.state = 'Red On'
             elif (self.__casu.get_range(casu.IR_NE) < 2 or
                   self.__casu.get_range(casu.IR_SE) < 2):
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
+                self.__casu.set_diagnostic_led_rgb(0, 1, 0, casu.DLED_TOP)
                 self.old_state = self.state
                 self.state = 'Green On'
             elif self.__casu.get_range(casu.IR_S) < 2:
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 0, 1)
+                self.__casu.set_diagnostic_led_rgb(0, 0, 1, casu.DLED_TOP)
                 self.old_state = self.state
                 self.state = 'Blue On'
             elif (self.__casu.get_range(casu.IR_SW) < 2 or
                   self.__casu.get_range(casu.IR_NW) < 2):
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 1, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 1, 0, casu.DLED_TOP)
                 self.old_state = self.state
                 self.state = 'Yellow On'
             else:

--- a/examples/targeted_messaging/README.md
+++ b/examples/targeted_messaging/README.md
@@ -1,0 +1,59 @@
+
+**Summary** This example shows how to use messaging between CASUs, where the
+identity of a message origin is relevant to the processing.
+
+**Expected behaviour** 
+When a bee goes past a sensor facing in the direction of the centre CASU, that
+CASU emits a message.
+
+When the message is received by the central CASU, it sets the LED according to
+the neighbour it was sent by.  This is set up logically, so if the behaviours
+are launched: 
+
+1. using <cfg-match>
+   then we use matching colors between the hub and spokes:
+   whatever color the spoke flashes, the hub should (approx) simultaneously
+   flash the same color. (red from the left, green from the right).
+2. using <cfg-diff> 
+   then we use differing colors between the hub and spokes:
+   whatever color the spoke flashes, the hub should (approx) simultaneously
+   flash the other color. (green from the left, red from the right).
+
+The examples illustrate that the connection (label) in the receiving CASU can be redefined easily, while the physical setup (port/host IP) need not be changed -- or indeed could be changed independently.
+
+# How to run
+1. start the simulator
+cd <wherever>
+./assisi_playground
+
+2. spawn the objects
+<run in this directory>
+python ./spawn_casus_bees.py
+
+3. run behaviour of bees
+- there is just one script for both bees.
+python circling_bees.py
+
+4. run CASU controllers -- in different terminals (or backgrounded)
+(set 1):
+python hub.py   --rtc-path cfg-diff --name casu-ctr
+python spoke.py --rtc-path cfg-diff --name casu-right -d W
+python spoke.py --rtc-path cfg-diff --name casu-left -d E
+
+(set 2):
+python hub.py   --rtc-path cfg-match --name casu-ctr
+python spoke.py --rtc-path cfg-match --name casu-right -d W
+python spoke.py --rtc-path cfg-match --name casu-left  -d E
+
+5. once done, <ctrl-c> should shut down the handlers gracefully
+(sometimes interaction with the threading library means it doesn't)
+
+*Note*: shut down clients first, then kill the assisi playground.
+
+ 
+
+# History
+April 2015 : Extended idea from `messaging`, to validate specific messaging.
+
+
+

--- a/examples/targeted_messaging/README.md
+++ b/examples/targeted_messaging/README.md
@@ -32,7 +32,8 @@ python ./spawn_casus_bees.py
 
 3. run behaviour of bees
 - there is just one script for both bees.
-python circling_bees.py
+python bees_circling.py 
+
 
 4. run CASU controllers -- in different terminals (or backgrounded)
 (set 1):

--- a/examples/targeted_messaging/bees_circling.py
+++ b/examples/targeted_messaging/bees_circling.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# A simple demo of bee-casu interaction
+
+from assisipy import bee
+import time 
+
+from math import pi
+
+if __name__ == '__main__':
+
+    # Connect to the bee
+    walkers = []
+    names = ['Bee-001', 'Bee-002']
+    walkers = [bee.Bee(name=n) for n in names]
+    
+    # Let the bee run in circles
+    for i, w in enumerate(walkers):
+        f = (i+1) * 1.0 # growth rate :)
+
+        w.set_vel(f*0.65, f*0.8)
+
+    try:
+        while True:
+            time.sleep(3.5)
+            pass
+    except KeyboardInterrupt:
+        print "shutting down bees..."
+        for w in walkers: 
+            w.set_vel(0, 0)
+
+
+
+    
+
+
+            
+
+    

--- a/examples/targeted_messaging/bees_circling.py
+++ b/examples/targeted_messaging/bees_circling.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# A simple demo of bee-casu interaction
+# A simple demo of bee-casu interaction, with bees rotating about 
+# CASUs to periodically trigger IR sensors.
 
 from assisipy import bee
 import time 
@@ -17,7 +18,7 @@ if __name__ == '__main__':
     
     # Let the bee run in circles
     for i, w in enumerate(walkers):
-        f = (i+1) * 1.0 # growth rate :)
+        f = (i+1) * 1.0 # growth rate
 
         w.set_vel(f*0.65, f*0.8)
 

--- a/examples/targeted_messaging/cfg-diff/casu-ctr.rtc
+++ b/examples/targeted_messaging/cfg-diff/casu-ctr.rtc
@@ -1,0 +1,11 @@
+name: casu-ctr
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50201
+neighbors:
+    green:
+        name: casu-left
+        address: tcp://localhost:50200
+    red:
+        name: casu-right
+        address: tcp://localhost:50202

--- a/examples/targeted_messaging/cfg-diff/casu-left.rtc
+++ b/examples/targeted_messaging/cfg-diff/casu-left.rtc
@@ -1,0 +1,8 @@
+name: casu-left
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50200
+neighbors:
+    collector:
+        name: casu-ctr
+        address: tcp://localhost:50201

--- a/examples/targeted_messaging/cfg-diff/casu-right.rtc
+++ b/examples/targeted_messaging/cfg-diff/casu-right.rtc
@@ -1,0 +1,8 @@
+name: casu-right
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50202
+neighbors:
+    collector:
+        name: casu-ctr
+        address: tcp://localhost:50201

--- a/examples/targeted_messaging/cfg-match/casu-ctr.rtc
+++ b/examples/targeted_messaging/cfg-match/casu-ctr.rtc
@@ -1,0 +1,11 @@
+name: casu-ctr
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50201
+neighbors:
+    red:
+        name: casu-left
+        address: tcp://localhost:50200
+    green:
+        name: casu-right
+        address: tcp://localhost:50202

--- a/examples/targeted_messaging/cfg-match/casu-left.rtc
+++ b/examples/targeted_messaging/cfg-match/casu-left.rtc
@@ -1,0 +1,8 @@
+name: casu-left
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50200
+neighbors:
+    collector:
+        name: casu-ctr
+        address: tcp://localhost:50201

--- a/examples/targeted_messaging/cfg-match/casu-right.rtc
+++ b/examples/targeted_messaging/cfg-match/casu-right.rtc
@@ -1,0 +1,8 @@
+name: casu-right
+pub_addr: tcp://localhost:5556
+sub_addr: tcp://localhost:5555
+msg_addr: tcp://*:50202
+neighbors:
+    collector:
+        name: casu-ctr
+        address: tcp://localhost:50201

--- a/examples/targeted_messaging/hub.py
+++ b/examples/targeted_messaging/hub.py
@@ -13,31 +13,6 @@ from assisipy import casu
 import argparse, os
 import time
 
-'''
-Note: the function `find_comm_links` is not needed in this example any
-longer, since the functionality is provided by the assisipy.Casu class.
-'''
-import yaml
-def find_comm_links(rtc, verb=False):
-    phys_logi_map = {}
-
-    try:
-        deploy = yaml.safe_load(file(rtc, 'r'))
-        # verify that the deployment file is for the same named object
-        if 'neighbors' in deploy and deploy['neighbors'] is not None:
-            for k, v in deploy['neighbors'].iteritems():
-                neigh = v.get('name', None)
-                if verb: print v, neigh
-                if neigh:
-                    phys_logi_map[neigh] = k
-
-    except IOError:
-        print "[W] could not read rtc conf file for casu {}".format(casu_name)
-    
-    return phys_logi_map
-
-
-
 
 class CasuController(object):
 

--- a/examples/targeted_messaging/hub.py
+++ b/examples/targeted_messaging/hub.py
@@ -38,7 +38,7 @@ class CasuController(object):
         self.old_state = 'Off'
         self.state = 'Off'
         self.verb = verb
-        self._comm_links = find_comm_links(rtc_file, verb=self.verb)
+        #self._comm_links = find_comm_links(rtc_file, verb=self.verb)
 
     def stop(self):
         self.__casu.stop()
@@ -54,7 +54,8 @@ class CasuController(object):
         msgs = self.recv_all_msgs(retry_cnt=0, max_recv=None)
         for msg in msgs:
             src_physical = msg['sender']
-            src_label = self._comm_links.get(src_physical, None)
+            #src_label = self._comm_links.get(src_physical, None)
+            src_label = msg['label']
 
             if src_label in ['red', 'green']:
                 self.old_state = self.state

--- a/examples/targeted_messaging/hub.py
+++ b/examples/targeted_messaging/hub.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Control of the central Casu
+# This responds to different incoming messages, in a different manner
+# according to the label.
+
+from assisipy import casu
+import argparse, os
+import time
+
+import yaml
+def find_comm_links(rtc, verb=False):
+    phys_logi_map = {}
+
+    try:
+        deploy = yaml.safe_load(file(rtc, 'r'))
+        # verify that the deployment file is for the same named object
+        if 'neighbors' in deploy and deploy['neighbors'] is not None:
+            for k, v in deploy['neighbors'].iteritems():
+                neigh = v.get('name', None)
+                if verb: print v, neigh
+                if neigh:
+                    phys_logi_map[neigh] = k
+
+    except IOError:
+        print "[W] could not read rtc conf file for casu {}".format(casu_name)
+    
+    return phys_logi_map
+
+
+
+
+class CasuController:
+
+    def __init__(self, rtc_file, verb=True):
+        self.__casu = casu.Casu(rtc_file)
+        self.old_state = 'Off'
+        self.state = 'Off'
+        self.verb = verb
+        self._comm_links = find_comm_links(rtc_file, verb=self.verb)
+
+    def stop(self):
+        self.__casu.stop()
+
+    def react_to_neighbors(self):
+        '''
+        read messages from afar, and change color according to the *channel* 
+        that the incoming message came from.  (optionally, message payload
+        indicates different factor - like how long to flash for/how intense?)
+
+        '''
+
+        msgs = self.recv_all_msgs(retry_cnt=0, max_recv=None)
+        for msg in msgs:
+            src_physical = msg['sender']
+            src_label = self._comm_links.get(src_physical, None)
+
+            if src_label in ['red', 'green']:
+                self.old_state = self.state
+                self.state = "{} {}".format(src_label, msg['data'])
+            else:
+                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Off'
+
+        if self.old_state != self.state:
+            if self.state == 'red On':
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+            elif self.state == 'green On':
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
+            else:
+                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
+
+
+
+
+    def recv_all_msgs(self, retry_cnt=0, max_recv=None):
+        '''
+        continue to read message bffer until no more messages.
+        return as list of messages (each msg is a dict)
+
+        '''
+        msgs = []
+        try_cnt = 0
+
+        while(True):
+            msg = self.__casu.read_message()
+            #print msg
+            if msg:
+                msgs.append(msg)
+
+                if self.verb:
+                    print "\t[i]<== recv msg ({1} by): from {0}".format(
+                        msg['sender'], len(msg['data']) )
+                if self.verb > 1:
+                    print msg.items()
+
+                if(max_recv is not None and len(msgs) >= max_recv):
+                    break
+            else:
+                # buffer emptied, return
+                try_cnt += 1
+                if try_cnt > retry_cnt:
+                    break
+
+        return msgs
+
+
+
+    def react_to_bees(self):
+        """
+        Changes color to red, when a bee is detected by one of the proximity sensors.
+        Notifies neighbor.
+        """
+        while True:
+            if self.__casu.get_range(casu.IR_N) < 2:
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.old_state = self.state
+                self.state = 'Red On'
+            elif (self.__casu.get_range(casu.IR_NE) < 2 or
+                  self.__casu.get_range(casu.IR_SE) < 2):
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
+                self.old_state = self.state
+                self.state = 'Green On'
+            elif self.__casu.get_range(casu.IR_S) < 2:
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 0, 1)
+                self.old_state = self.state
+                self.state = 'Blue On'
+            elif (self.__casu.get_range(casu.IR_SW) < 2 or
+                  self.__casu.get_range(casu.IR_NW) < 2):
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 1, 0)
+                self.old_state = self.state
+                self.state = 'Yellow On'
+            else:
+                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Off'
+
+            if self.old_state != self.state:
+                if self.old_state == 'Red On':
+                    self.__casu.send_message('north', 'Off')
+                elif self.old_state == 'Green On':
+                    self.__casu.send_message('east', 'Off')
+                elif self.old_state == 'Blue On':
+                    self.__casu.send_message('south', 'Off')
+                elif self.old_state == 'Yellow On':
+                    self.__casu.send_message('west', 'Off')
+
+                if self.state == 'Red On':
+                    self.__casu.send_message('north', 'On')
+                if self.state == 'Green On':
+                    self.__casu.send_message('east', 'On')
+                if self.state == 'Blue On':
+                    self.__casu.send_message('south', 'On')
+                if self.state == 'Yellow On':
+                    self.__casu.send_message('west', 'On')
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--rtc-path', type=str, default='',
+            help="location of RTC files to configure CASUs",)
+    parser.add_argument('-n', '--name', type=str, default='casu-ctr',
+            help="location of RTC files to configure CASUs",)
+    parser.add_argument('-v', '--verb', type=int, default=1,
+            help="verbosity level")
+    args = parser.parse_args()
+
+    fname = "{}.rtc".format(args.name)
+    rtc = os.path.join(args.rtc_path, fname)
+    print "connecting to casu {} ('{}')".format(args.name, rtc)
+
+    ctrl = CasuController(rtc_file=rtc)
+
+    try:
+        while True:
+            ctrl.react_to_neighbors()
+            #time.sleep(0.5)
+    except KeyboardInterrupt:
+        # cleanup
+        ctrl.stop()
+
+
+
+        
+        
+

--- a/examples/targeted_messaging/hub.py
+++ b/examples/targeted_messaging/hub.py
@@ -31,7 +31,7 @@ def find_comm_links(rtc, verb=False):
 
 
 
-class CasuController:
+class CasuController(object):
 
     def __init__(self, rtc_file, verb=True):
         self.__casu = casu.Casu(rtc_file)
@@ -64,11 +64,15 @@ class CasuController:
                 self.old_state = self.state
                 self.state = 'Off'
 
+            if self.verb:
+                print "[I] rx msg from {} (link {}), new state is {}".format(
+                        src_physical, src_label, self.state)
+
         if self.old_state != self.state:
             if self.state == 'red On':
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
             elif self.state == 'green On':
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
+                self.__casu.set_diagnostic_led_rgb(0, 1, 0, casu.DLED_TOP)
             else:
                 self.__casu.diagnostic_led_standby(casu.DLED_TOP)
 

--- a/examples/targeted_messaging/spawn_casus_bees.py
+++ b/examples/targeted_messaging/spawn_casus_bees.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+A simple simulation environment with one Casu and one bee.
+"""
+
+from assisipy import sim
+
+from math import pi
+
+if __name__ == '__main__':
+
+    simctrl = sim.Control()
+    
+    # Spawn bees and casus (syntax is 'type', 'name', (x,y,yaw))
+    simctrl.spawn('Casu','casu-ctr',   (0,0, pi/2)) 
+    simctrl.spawn('Casu','casu-left',  (-9,0, pi/2)) 
+    simctrl.spawn('Casu','casu-right', (+9,0, pi/2)) 
+
+    #simctrl.spawn('Casu','Casu-01-02',(0,9,pi/2))
+    #simctrl.spawn('Casu','Casu-02-01',(-9,0,pi/2))
+    #simctrl.spawn('Casu','Casu-02-03',(9,0,pi/2))
+    #simctrl.spawn('Casu','Casu-03-02',(0,-9,pi/2))
+    simctrl.spawn('Bee','Bee-001',(-9+2, 0, pi/2))
+    simctrl.spawn('Bee','Bee-002',(+9+0,+2, 2*pi/2))

--- a/examples/targeted_messaging/spawn_casus_bees.py
+++ b/examples/targeted_messaging/spawn_casus_bees.py
@@ -21,9 +21,5 @@ if __name__ == '__main__':
     simctrl.spawn('Casu','casu-left',  (-9,0, yaw))
     simctrl.spawn('Casu','casu-right', (+9,0, yaw))
 
-    #simctrl.spawn('Casu','Casu-01-02',(0,9,pi/2))
-    #simctrl.spawn('Casu','Casu-02-01',(-9,0,pi/2))
-    #simctrl.spawn('Casu','Casu-02-03',(9,0,pi/2))
-    #simctrl.spawn('Casu','Casu-03-02',(0,-9,pi/2))
     simctrl.spawn('Bee','Bee-001',(-9+2, 0, pi/2))
     simctrl.spawn('Bee','Bee-002',(+9+0,+2, 2*pi/2))

--- a/examples/targeted_messaging/spawn_casus_bees.py
+++ b/examples/targeted_messaging/spawn_casus_bees.py
@@ -14,9 +14,12 @@ if __name__ == '__main__':
     simctrl = sim.Control()
     
     # Spawn bees and casus (syntax is 'type', 'name', (x,y,yaw))
-    simctrl.spawn('Casu','casu-ctr',   (0,0, pi/2)) 
-    simctrl.spawn('Casu','casu-left',  (-9,0, pi/2)) 
-    simctrl.spawn('Casu','casu-right', (+9,0, pi/2)) 
+    #yaw = 0.0 # this points to the RIGHT
+    yaw = pi/2 # this points UP 
+    #yaw = -pi/2 # this points down, 
+    simctrl.spawn('Casu','casu-ctr',   (0,0, yaw))
+    simctrl.spawn('Casu','casu-left',  (-9,0, yaw))
+    simctrl.spawn('Casu','casu-right', (+9,0, yaw))
 
     #simctrl.spawn('Casu','Casu-01-02',(0,9,pi/2))
     #simctrl.spawn('Casu','Casu-02-01',(-9,0,pi/2))

--- a/examples/targeted_messaging/spoke.py
+++ b/examples/targeted_messaging/spoke.py
@@ -31,35 +31,35 @@ class CasuController:
         msg = self.__casu.read_message()
         if msg:
             if  msg['data'] == 'On':
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
             else:
                 self.__casu.diagnostic_led_standby(casu.DLED_TOP)
             
     def send_msg(self):
 
         while True:
-            # North side
+            # North side => yellow
             if self._ctr_dir == 'N' and  self.__casu.get_range(casu.IR_N) < 2:
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
-                self.old_state = self.state
-                self.state = 'Red On'
-            # East
-            elif self._ctr_dir == 'E' and ((self.__casu.get_range(casu.IR_NE) <
-                2 or self.__casu.get_range(casu.IR_SE) < 2)):
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
-                self.old_state = self.state
-                self.state = 'Green On'
-            # West
-            elif self._ctr_dir == 'W' and self.__casu.get_range(casu.IR_S) < 2:
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 0, 1)
-                self.old_state = self.state
-                self.state = 'Blue On'
-            # South
-            elif self._ctr_dir == 'S' and ((self.__casu.get_range(casu.IR_SW) <
-                2 or self.__casu.get_range(casu.IR_NW) < 2)):
-                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 1, 0)
+                self.__casu.set_diagnostic_led_rgb(1, 1, 0, casu.DLED_TOP)
                 self.old_state = self.state
                 self.state = 'Yellow On'
+            # East => red
+            elif self._ctr_dir == 'E' and ((self.__casu.get_range(casu.IR_NE) <
+                2 or self.__casu.get_range(casu.IR_SE) < 2)):
+                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Red On'
+            # South => blue
+            elif self._ctr_dir == 'S' and self.__casu.get_range(casu.IR_S) < 2:
+                self.__casu.set_diagnostic_led_rgb(0, 0, 1, casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Blue On'
+            # West => green
+            elif self._ctr_dir == 'W' and ((self.__casu.get_range(casu.IR_SW) <
+                2 or self.__casu.get_range(casu.IR_NW) < 2)):
+                self.__casu.set_diagnostic_led_rgb(0, 1, 0, casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Green On'
             else:
                 self.__casu.diagnostic_led_standby(casu.DLED_TOP)
                 self.old_state = self.state

--- a/examples/targeted_messaging/spoke.py
+++ b/examples/targeted_messaging/spoke.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# for all "spoke" CASUs, they emit when reading one specific directional
+# IR sensor.
+
+
+from assisipy import casu
+import argparse, os
+from hub import find_comm_links
+import time
+
+class CasuController:
+
+    def __init__(self, rtc_file, direction, verb=False):
+        self.__casu = casu.Casu(rtc_file)
+        self._ctr_dir = direction
+        self.old_state = 'Off'
+        self.state = 'Off'
+        self.verb = verb
+        self._comm_links = find_comm_links(rtc_file, verb=self.verb)
+
+    def stop(self):
+        self.__casu.stop()
+
+    def handle_message(self):
+        """
+        Changes color to red, when a bee is detected by one of the proximity sensors.
+        Notifies neighbor.
+        """
+        msg = self.__casu.read_message()
+        if msg:
+            if  msg['data'] == 'On':
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+            else:
+                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
+            
+    def send_msg(self):
+
+        while True:
+            # North side
+            if self._ctr_dir == 'N' and  self.__casu.get_range(casu.IR_N) < 2:
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 0, 0)
+                self.old_state = self.state
+                self.state = 'Red On'
+            # East
+            elif self._ctr_dir == 'E' and ((self.__casu.get_range(casu.IR_NE) <
+                2 or self.__casu.get_range(casu.IR_SE) < 2)):
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 1, 0)
+                self.old_state = self.state
+                self.state = 'Green On'
+            # West
+            elif self._ctr_dir == 'W' and self.__casu.get_range(casu.IR_S) < 2:
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 0, 0, 1)
+                self.old_state = self.state
+                self.state = 'Blue On'
+            # South
+            elif self._ctr_dir == 'S' and ((self.__casu.get_range(casu.IR_SW) <
+                2 or self.__casu.get_range(casu.IR_NW) < 2)):
+                self.__casu.set_diagnostic_led_rgb(casu.DLED_TOP, 1, 1, 0)
+                self.old_state = self.state
+                self.state = 'Yellow On'
+            else:
+                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
+                self.old_state = self.state
+                self.state = 'Off'
+
+            if self.old_state != self.state:
+                if self.old_state == 'Red On':
+                    self.__casu.send_message('collector', 'Off')
+                elif self.old_state == 'Green On':
+                    self.__casu.send_message('collector', 'Off')
+                elif self.old_state == 'Blue On':
+                    self.__casu.send_message('collector', 'Off')
+                elif self.old_state == 'Yellow On':
+                    self.__casu.send_message('collector', 'Off')
+
+                if self.state == 'Red On':
+                    self.__casu.send_message('collector', 'On')
+                if self.state == 'Green On':
+                    self.__casu.send_message('collector', 'On')
+                if self.state == 'Blue On':
+                    self.__casu.send_message('collector', 'On')
+                if self.state == 'Yellow On':
+                    self.__casu.send_message('collector', 'On')
+
+
+
+    def loop(self):
+        """
+        Do some smart control stuff...
+        """
+        while True:
+            self.send_msg()
+            time.sleep(0.5)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--rtc-path', type=str, default='',
+            help="location of RTC files to configure CASUs",)
+    parser.add_argument('-n', '--name', type=str, default='casu-ctr',
+            help="location of RTC files to configure CASUs",)
+    parser.add_argument('-v', '--verb', type=int, default=1,
+            help="verbosity level")
+    parser.add_argument('-d', '--dir', type=str, default='N',
+            help="direction of centre")
+    args = parser.parse_args()
+
+    fname = "{}.rtc".format(args.name)
+    rtc = os.path.join(args.rtc_path, fname)
+    print "connecting to casu {} ('{}')".format(args.name, rtc)
+
+    ctrl = CasuController(rtc_file=rtc, direction=args.dir)
+
+    try:
+        while True:
+            ctrl.loop()
+    except KeyboardInterrupt:
+        # cleanup
+        ctrl.stop()
+
+
+
+

--- a/examples/targeted_messaging/spoke.py
+++ b/examples/targeted_messaging/spoke.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# for all "spoke" CASUs, they emit when reading one specific directional
-# IR sensor.
+'''
+for all "spoke" CASUs, they emit when reading one specific directional
+IR sensor.
 
+set the direction that is sensed by the -d flag, from NESW
+
+'''
 
 from assisipy import casu
 import argparse, os
-from hub import find_comm_links
 import time
 
 class CasuController:
@@ -18,22 +21,9 @@ class CasuController:
         self.old_state = 'Off'
         self.state = 'Off'
         self.verb = verb
-        self._comm_links = find_comm_links(rtc_file, verb=self.verb)
 
     def stop(self):
         self.__casu.stop()
-
-    def handle_message(self):
-        """
-        Changes color to red, when a bee is detected by one of the proximity sensors.
-        Notifies neighbor.
-        """
-        msg = self.__casu.read_message()
-        if msg:
-            if  msg['data'] == 'On':
-                self.__casu.set_diagnostic_led_rgb(1, 0, 0, casu.DLED_TOP)
-            else:
-                self.__casu.diagnostic_led_standby(casu.DLED_TOP)
             
     def send_msg(self):
 
@@ -66,24 +56,13 @@ class CasuController:
                 self.state = 'Off'
 
             if self.old_state != self.state:
-                if self.old_state == 'Red On':
-                    self.__casu.send_message('collector', 'Off')
-                elif self.old_state == 'Green On':
-                    self.__casu.send_message('collector', 'Off')
-                elif self.old_state == 'Blue On':
-                    self.__casu.send_message('collector', 'Off')
-                elif self.old_state == 'Yellow On':
+                if self.old_state in ['Red On', 'Green On', 'Blue On', 
+                        'Yellow On']:
                     self.__casu.send_message('collector', 'Off')
 
-                if self.state == 'Red On':
+                if self.state in ['Red On', 'Green On', 'Blue On', 
+                        'Yellow On']:
                     self.__casu.send_message('collector', 'On')
-                if self.state == 'Green On':
-                    self.__casu.send_message('collector', 'On')
-                if self.state == 'Blue On':
-                    self.__casu.send_message('collector', 'On')
-                if self.state == 'Yellow On':
-                    self.__casu.send_message('collector', 'On')
-
 
 
     def loop(self):
@@ -110,7 +89,7 @@ if __name__ == '__main__':
     rtc = os.path.join(args.rtc_path, fname)
     print "connecting to casu {} ('{}')".format(args.name, rtc)
 
-    ctrl = CasuController(rtc_file=rtc, direction=args.dir)
+    ctrl = CasuController(rtc_file=rtc, direction=args.dir, verb=args.verb)
 
     try:
         while True:


### PR DESCRIPTION
1. Small changes add a dictionary that is read from the RTC file on Casu instance initialisation.
2. a new example, `targeted_messaging`, to illustrate the new functionality

Resolves #10.


- note: is it worth making the RTC files mandatory for CASUs? Or an explicit acknowledgement from the user that they are aware of not using one?