### PR TITLE
Code to prepare/generate package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+# this file is necessary because setuptools will ignore any entries in 
+#   data_files, package_data
+# if they are not within a python package, and possibly altogether if 
+# compiling source distributions ("python setup.py sdist")
+# see, e.g., http://stackoverflow.com/a/1857436
+
+include DESCRIPTION.rst

--- a/assisipy/assisirun.py
+++ b/assisipy/assisirun.py
@@ -5,11 +5,12 @@
 Tool for remotely running CASU controllers.
 """
 
-from fabric.api import settings, cd, run, env
+# none of the fabric tools are used [directly], import removed
+#from fabric.api import settings, cd, run, env
 
 import yaml
 
-import os.path
+#import os.path
 import argparse
 import subprocess
 
@@ -21,7 +22,7 @@ class AssisiRun:
         """
         Constructor.
         """
-        
+
         self.fabfile_name = project_name[:-6] + 'py'
         self.depspec = {}
         with open(project_name) as project:
@@ -48,11 +49,13 @@ class AssisiRun:
         for taskname in self.running:
             self.running[taskname].wait()
 
-if __name__ == '__main__':
-    
+def main():
     parser = argparse.ArgumentParser(description='Run a set of CASU controllers.')
     parser.add_argument('project', help='name of .assisi file specifying the project details.')
     args = parser.parse_args()
 
     project = AssisiRun(args.project)
     project.run()
+
+if __name__ == '__main__':
+    main()

--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -86,8 +86,7 @@ class DataCollector:
         os.chdir(self.project_root)
 
 
-if __name__ == '__main__':
-
+def main():
     parser = argparse.ArgumentParser(description='Collect CASU logs. Currently assumes that the logs are located in the same folder as the controller.')
     parser.add_argument('project', help='Project file name (.assisi).')
     parser.add_argument('--clean', action='store_true', default=False,
@@ -96,3 +95,5 @@ if __name__ == '__main__':
     dc = DataCollector(args.project, args.clean)
     dc.collect()
 
+if __name__ == '__main__':
+    main()

--- a/assisipy/sim.py
+++ b/assisipy/sim.py
@@ -15,11 +15,11 @@ from msg import base_msgs_pb2
 from msg import dev_msgs_pb2
 
 class Control:
-    """ 
-    Simulator control API. 
+    """
+    Simulator control API.
 
-    Creates a command publisher and connects it to the simulator. 
-        
+    Creates a command publisher and connects it to the simulator.
+
     :param string rtc_file_name: Name of the run-time configuraiton file. This file specifies the parameters for connecting to the simulator.
 
     """
@@ -56,24 +56,24 @@ class Control:
                 time.sleep(1)
             print('Simulator control connected!')
 
-    def spawn(self, 
-              obj_type, 
-              name, 
-              pose, 
-              polygon = (), 
-              radius = (), 
+    def spawn(self,
+              obj_type,
+              name,
+              pose,
+              polygon = (),
+              radius = (),
               color = (),
               height = 1,
               mass = -1):
-        """ 
+        """
 
         Spawn an object in the simulated world.
-            
+
         :param str obj_type: Type of object to spawn. Currently supported types are 'Casu', 'Bee', 'EPuck' and 'Physical'
         :param str name: Name of the object. Must be unique in the world.
         :param tuple pose: An (x,y,yaw) tuple.
         :param tuple polygon: A tuple of vertex coordinates ((x1,y1),(x2,y2),...). If obj_type is 'Physical', this defines the shape of the object.
-        :param radius: Radius of a cylindrical 'Physical' object. 
+        :param radius: Radius of a cylindrical 'Physical' object.
         :param color: Color of a 'Physical' object.
         :param float height: 'Physical' object height.
         :param mass: 'Physical' object mass.
@@ -103,7 +103,7 @@ class Control:
             data.polygon.height = height
             data.polygon.mass = mass
             data.type = 'Polygon'
-        self.__pub.send_multipart(['Sim', 'Spawn', obj_type, 
+        self.__pub.send_multipart(['Sim', 'Spawn', obj_type,
                                    data.SerializeToString()])
 
     def spawn_array(self, obj_type, array):
@@ -111,7 +111,7 @@ class Control:
         Spawn an array of objects.
         """
         for name in array:
-            self.spawn(obj_type, name, 
+            self.spawn(obj_type, name,
                        (array[name]['pose']['x'],
                         array[name]['pose']['y'],
                         array[name]['pose']['yaw']))
@@ -172,8 +172,8 @@ class Control:
                     print('Unknown command {0} for sim control'.format(cmd))
 
 
-if __name__ == '__main__':
 
+def main():
     parser = argparse.ArgumentParser(description='Spawn an array of objects (casus or bees), from an .arena/.bees file.')
     parser.add_argument('filename', help='an .arena or .bees file')
     args = parser.parse_args()
@@ -192,3 +192,5 @@ if __name__ == '__main__':
                     sim_ctrl = Control(pub_addr = arrays[layer][obj_name]['pub_addr'])
                     sim_ctrl.spawn_array(obj_type, arrays[layer])
 
+if __name__ == '__main__':
+    main()

--- a/create_package.sh
+++ b/create_package.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# make sure the messages are up to date
+git submodule update --init
+./compile_msgs.sh
+
+# get some extra meta-data, and append to the readme 
+assisipy_rev=`git rev-parse HEAD`
+assisi_msg_rev=`cd msg && git rev-parse HEAD`
+assisipy_ver=`python -c "import assisipy; print assisipy.__version__"`
+
+# but first, ensure we are working with the repo version
+README=README.rst
+#README=/dev/null
+if [ -f "${README}" ] ; then
+    git checkout -- ${README}
+else
+    echo "[I] skipping cleanup"
+fi
+
+printf "\n\n" | tee -a ${README}
+printf "============================================================\n" | tee -a ${README}
+printf "This release was sourced from:\n"               | tee -a ${README}
+printf "\tassisi-python git rev %s\n" ${assisipy_rev}   | tee -a ${README}
+printf "\tassisi-msg    git rev %s\n" ${assisi_msg_rev} | tee -a ${README}
+printf "\tassisi-python version %s\n" ${assisipy_ver}   | tee -a ${README}
+printf "============================================================\n" | tee -a ${README}
+
+# exec the setup script to produce a package
+python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
-# The package setup file
-# Based on: https://github.com/pypa/sampleproject/blob/master/setup.py
+'''
+A setuptools script that follows recommendations (where relevant) from:
+  https://github.com/pypa/sampleproject/blob/master/setup.py
+  https://github.com/jeffknupp/sandman/blob/develop/setup.py
+  http://pythonhosted.org/setuptools/setuptools.html
+
+Note: to ensure that the description file is available in the target,
+(needed when setup.py is executed, either manually or by easy_install/pip)
+the MANIFEST.in file is used.
+package_data and data_files are ignored by setuptools when compiling
+source distributions!
+
+'''
+
 
 from setuptools import setup, find_packages
 import codecs
@@ -8,29 +20,27 @@ import re
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-# Read the version number from a source file
-def find_version(*file_paths):
-    # Open in Latin-1 to avoid encoding errors
-    # Use codecs.open for Python 2 compatibility
-    with codecs.open(os.path.join(here, *file_paths), 'r', 'latin1') as f:
-        version_file = f.read()
+def read(*parts):
+    # source: https://github.com/jeffknupp/sandman/blob/develop/setup.py
+    # intentionally *not* adding an encoding option to open
+    return codecs.open(os.path.join(here, *parts), 'r').read()
 
-    # The version line must have the form
-    # __version__ = 'ver'
+def find_version(*file_paths):
+    # source: https://github.com/jeffknupp/sandman/blob/develop/setup.py
+    version_file = read(*file_paths)
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
-
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
-# Get the long description from the relevant file
-with codecs.open('DESCRIPTION.rst', encoding='utf-8') as f:
-    long_description = f.read()
+long_description = read('DESCRIPTION.rst')
 
 setup(
     name="assisipy",
     version=find_version('assisipy', '__init__.py'),
+    packages=find_packages(exclude=["doc"]),
+
     description="Python API for the ASSISbf project",
     long_description=long_description,
 
@@ -56,22 +66,8 @@ setup(
 
     keywords='assisi, assisibf, collective systems',
 
-    packages=find_packages(exclude=["doc"]),
-
     # Run-time dependencies (will be installed by pip)
-    install_requires = ['pyzmq','protobuf','pyyaml'],
+    install_requires = ['pyzmq','protobuf','pyyaml', 'pygraphviz', 'Fabric'],
 
-    # Additional files to be installed
-    #package_data={
-    #    'sample': ['package_data.dat'],
-    #},
 
-    # Provide executable scripts
-    entry_points={
-        'console_scripts': [
-            'sample=sample:main',
-        ],
-    },
 )
-
-    

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,19 @@ A setuptools script that follows recommendations (where relevant) from:
   https://github.com/jeffknupp/sandman/blob/develop/setup.py
   http://pythonhosted.org/setuptools/setuptools.html
 
+
 Note: to ensure that the description file is available in the target,
 (needed when setup.py is executed, either manually or by easy_install/pip)
 the MANIFEST.in file is used.
 package_data and data_files are ignored by setuptools when compiling
 source distributions!
+
+Note: for the entry points to work, the rhs expects the target to be a
+function in a module, that takes no arguments:
+http://stackoverflow.com/q/2853088
+Luckily, argparse somehow access sys.argv from wherever they are created
+so arguments need to be passed to that entry point func.
+The four tools used in deployment scenarios have these entry points set up.
 
 '''
 
@@ -35,6 +43,16 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 long_description = read('DESCRIPTION.rst')
+
+# setting up entry points to code within the python package - hopefully..
+console_scripts = [
+            ['sim.py = assisipy.sim:main'],
+            ['assisirun.py = assisipy.assisirun:main'],
+            ['deploy.py = assisipy.deploy:main'],
+            ['collect_data.py = assisipy.collect_data:main'],
+]
+
+
 
 setup(
     name="assisipy",
@@ -69,5 +87,8 @@ setup(
     # Run-time dependencies (will be installed by pip)
     install_requires = ['pyzmq','protobuf','pyyaml', 'pygraphviz', 'Fabric'],
 
+    entry_points     = {
+        'console_scripts': console_scripts,
+    }
 
 )


### PR DESCRIPTION
The setup.py script is updated to manage generation of a package/bundle that is installable by pip.

- includes scripts/entry points for the main deployment tools 
   - these are installed to /usr/local/bin (default, linux; windows install does something sensible but I don't have a platform to test). 
   - this should rule out the need for adding the assisipy directory to the PATH variable.

- tested with a simple scenario using the deployment toolsuite above; installs and uninstalls ok.  


Some open issues:

**version numbers:** there is already a version v2.0.0; to harmonise numbers with recent release of the assisi-playground would ask for this to go backwards. 

**python dependencies**: As far as I can tell, the dependencies we have are covered (`snakefood` used to identify).  However, I didn't put version numbers of the dependencies, since I don't know what the minimal requirements are.  However, I think the pyzmq version is quite critical to successful operation. (Though maybe it just needs to be the same version in the simulator and API).

**examples**: The generated package does not at present include the examples directory.  I don't really like the idea of installing user "trial code" in system locations, as it may encourage editing of these files and subsequently others.  But we do need some way of distributing the examples too.

**the msg submodule**: setuptools does allow for custom code to be executed during installation of a package.  This *could* be used to fetch the assisi-msg repo, but it seemed cleaner to me to just ensure that the submodule is up to date when the package is generated. This step is included in the "create_package" script.

