### PR TITLE
Handle additional arguments in .dep file 

### DIFF
--- a/assisipy/deploy.py
+++ b/assisipy/deploy.py
@@ -121,19 +121,25 @@ def all():
                     for item in extra:
                         shutil.copy(os.path.join(self.project_root,item),'.')
 
+                # compile extra args string
+                _extra_args = self.dep[layer][casu].get('args', [])
+                extra_args = " ".join(_extra_args)
+
                 # Append to fabfile
                 fabfile_tasks += '''
 @parallel
 def {task}():
     with settings(host_string='{host}', user='{username}'):
         with cd('{code_dir}'):
-                run('export PYTHONPATH=/home/assisi/python:$PYTHONPATH; ./{command} {rtc}')
+                run('export PYTHONPATH=/home/assisi/python:$PYTHONPATH; ./{command} {rtc} {extra_args}')
                                   '''.format(task=(layer+'_'+casu).replace('-','_'),
                                              host=self.dep[layer][casu]['hostname'],
                                              username=self.dep[layer][casu]['user'],
                                              code_dir=os.path.join(self.dep[layer][casu]['prefix'],layer,casu),
                                              command=os.path.basename(self.dep[layer][casu]['controller']),
-                                             rtc=casu+'.rtc')
+                                             rtc=casu+'.rtc',
+                                             extra_args=extra_args,
+                                             )
                 fabfile_all += '    {task}()\n'.format(task=(layer+'_'+casu).replace('-','_'))
                 os.chdir('..')
             os.chdir(sandbox_path)

--- a/examples/deployment/simple/controllers/blink_and_send.py
+++ b/examples/deployment/simple/controllers/blink_and_send.py
@@ -4,8 +4,12 @@
 """
 Blinking CASU behavior.
 Waits for message from any neighbors.
-When a message arrives, blinks it's LED and forwards 
+When a message arrives, blinks it's LED and forwards
 the message.
+
+Optional argument sets the LED channel that will be active.
+(v. simple parsing only works for strings r,g,b; it is intended
+ to demonstrate `extra_args` in dep files & not LEDs per se)
 """
 
 from assisipy import casu
@@ -16,6 +20,16 @@ import time
 if __name__ == '__main__':
 
     c = casu.Casu(sys.argv[1], log=True)
+    # look for color specification in extra cmd-line arg.
+    LED_colors = [1, 0, 0]
+    if len(sys.argv)>2:
+        _defn = sys.argv[2]
+        LED_colors = [0, 0, 0]
+        if 'r' in _defn: LED_colors[0] = 1
+        if 'g' in _defn: LED_colors[1] = 1
+        if 'b' in _defn: LED_colors[2] = 1
+
+
 
     counter = 0
     while True:
@@ -30,9 +44,9 @@ if __name__ == '__main__':
             c.read_message()
 
         # Blink
-        c.set_diagnostic_led_rgb(r=1)
+        c.set_diagnostic_led_rgb(*LED_colors)
         time.sleep(1)
-        c.set_diagnostic_led_rgb(r=0)
+        c.set_diagnostic_led_rgb(r=0, g=0, b=0)
         time.sleep(1)
 
         # Forward message

--- a/examples/deployment/simple/local.dep
+++ b/examples/deployment/simple/local.dep
@@ -23,6 +23,9 @@ sim-01 :
         user : assisi
         prefix : deploy
         controller: controllers/blink_and_send.py
+        # if command-line arguments to the controller are required, supply as 
+        # a list in 'args'. ([] brackets required as per the 'extra' setting)
+        args : [ rg,]
     casu-004 : 
         hostname : localhost
         user : assisi
@@ -33,6 +36,7 @@ sim-01 :
         user : assisi
         prefix : deploy
         controller: controllers/blink_and_send.py
+        args : [ b]
     casu-006 : 
         hostname : localhost
         user : assisi
@@ -53,6 +57,5 @@ sim-01 :
         user : assisi
         prefix : deploy
         controller: controllers/blink_and_send.py
-
             
         


### PR DESCRIPTION
Extra arguments, if specified in the .dep file, get passed to the CASU controller.

Example also provided (via modification to "deployment/simple").

Closes issue #31