### PR TITLE
Updated docs re: pip installation (and examples/api repository split)

### DIFF
--- a/doc/src/dev-guide.rst
+++ b/doc/src/dev-guide.rst
@@ -1,0 +1,104 @@
+Installation instructions for development mode
+==============================================
+
+The primary :ref:`Installation instructions`_ indicate how to install the 
+assisi playground and API (`assisipy`) in user-mode.
+
+For development purposes, it may be preferrable to install either the playground or the API (or both) directly from the github 
+source.  
+
+.. Here we provide instructions for each part independently.
+
+**Playground** At present the main playground code is installed in this way,
+so consult the primary guide.
+
+**assisipy API** Rather than following step 3 of :ref:`Building the assisi software`_ in the primary guide, follow the steps below.
+
+
+
+Assumptions of prior installation
+---------------------------------
+
+
+Here we assume that you are using Ubuntu /debian 14.04 and have the directory structure:
+
+  * assisi
+
+    - playground
+    - examples
+    - python
+    - deps
+
+      + enki
+
+and that you have already followed the steps below from the primary guide:
+
+  - dependencies from the standard repositories (i.e., through `apt-get`)
+  - enki dependency, from github, compiled and installed / available on the system path, probably in /usr/local/include
+  - assisi playground software, from github, compiled, and the executable on your system path (or added to the PATH environment variable when needed) 
+     - the installation completed correctly using an up-to-date msg submodule.
+
+
+The Python API
+--------------
+
+.. code-block:: console
+
+  git clone https://github.com/larics/assisi-python python
+  cd python
+  git submodule update --init
+  ./compile_msgs.sh
+  export PYTHONPATH=${PYTHONPATH}:~/assisi/python
+  cd ..
+
+The ``PATH`` and ``PYTHONPATH`` exports have to be done very time you open a new shell, so It's best to add it to the end of your ``~/.bashrc`` file. It's purpose is to enable the importing of the Assisi python API in Python programs.
+
+
+Setting up a dual-source repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two main methods that developers contribute to the assisi playground source:
+
+1. having read-write access to https://github.com/larics/assisi-python
+2. using read-only access to github/larics/assisi-python; modifying a fork, and contributing via pull requests.
+
+To configure a repository for route #1:
+
+.. code-block:: console
+
+  git clone git@github.com:larics/assisi-python.git python 
+
+  cd python
+  git submodule update --init
+  ./compile_msgs.sh
+  export PYTHONPATH=${PYTHONPATH}:~/assisi/python
+  cd ..
+
+To configure a repository for route #2:
+
+.. code-block:: console
+
+  # set up your own fork with r+w
+  git clone git@github.com:<GH-USER>/assisi-python.git python
+  cd python
+  git submodule update --init
+  ./compile_msgs.sh
+
+  # now add the remote 
+  git remote add upstream https://github.com/larics/assisi-playground
+  git fetch
+
+
+See the github `gitflow page <https://guides.github.com/introduction/flow/>`_ for info on the workflow - in brief, in involves:
+
+- sync your fork:master with the upstream:master
+- branch from your master
+- commit changes to your new feature branch
+- push to your fork
+- create a pull request from your fork to the upstream
+
+
+
+
+
+

--- a/doc/src/examples.rst
+++ b/doc/src/examples.rst
@@ -1,5 +1,8 @@
 Examples of assisipy usage
 ==========================
 
-.. include:: ../../examples/deployment/simple/simple.rst
+See documentation included with the examples repository (https://github.com/assisi/assisipy-examples)
+
+
+.. .. include:: ../../examples/deployment/simple/simple.rst
 

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -17,6 +17,7 @@ Contents:
    manual
    protocol
    examples
+   dev-guide
 
 Indices and tables
 ==================

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -19,6 +19,11 @@ Contents:
    examples
    dev-guide
 
+.. toctree::
+   :hidden:
+
+   older-platform-install
+
 Indices and tables
 ==================
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -41,7 +41,9 @@ originally built it and run ``make uninstall``
 The next step is `Building the assisi software`_ 
 
 Ubuntu 12.04 (Precise) 64-bit
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+NOTE: if you are using ubuntu 14.04, skip this section.
 
 Most of the dependencies needed to build and run ASSISI software can
 be installed from official Ubuntu repositories:
@@ -100,10 +102,14 @@ MacOS X
 
 TODO
 
+
+
 Building the assisi software
 ----------------------------
 
-The assisi-playground simulator uses the Enki simulation engine, which
+There are three main components to install.
+
+1. The assisi-playground simulator uses the **Enki simulation engine**, which
 needs to be installed first:
 
 .. code-block:: console
@@ -121,9 +127,9 @@ needs to be installed first:
     cd ../../..
   
 
-You should have enki and viewer folders in you ``/user/local/include`` folder.
+You should have enki and viewer folders in you ``/usr/local/include`` folder.
 
-The assisi-playground itself:
+2. The **assisi-playground** itself:
 
 .. code-block:: console
 
@@ -137,7 +143,38 @@ The assisi-playground itself:
   export PATH=${PATH}:~/assisi/playground/build/playground
   cd ../..
   
-The Python API
+3. The **python API**:
+
+(These instructions are valid from December 2015 onwards, using >=v0.9.0)
+
+.. code-block:: console
+
+  sudo pip install assisipy
+
+
+
+The ``PATH`` export has to be done very time you open a new shell, so It's best to add it to the end of your ``~/.bashrc`` file. It's purpose is to enable the importing of the Assisi python API in Python programs.
+
+
+After completing all of the abovementioned steps, we should have the following folder structure:
+  * assisi
+
+    - playground
+    - examples
+    - deps
+
+      + enki
+
+(Note for older installation, e.g. Ubuntu 12.04, the ``assisi/deps`` directory
+should also contain sub-directories for ``cppzmq`` and ``zeromq-3.2.4``).
+
+    
+
+
+
+Installing the Python API -- old version (pre v0.9.0)
+-----------------------------------------------------
+
 
 .. code-block:: console
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -152,8 +152,22 @@ You should have enki and viewer folders in you ``/usr/local/include`` folder.
   sudo pip install assisipy
 
 
-
 The ``PATH`` export has to be done very time you open a new shell, so It's best to add it to the end of your ``~/.bashrc`` file. It's purpose is to enable the importing of the Assisi python API in Python programs.
+
+
+Examples (optional)
+-------------------
+
+A variety of code examples are provided, which illustrate how to use the API to run simulations and execute code on the physical CASUs.
+
+.. code-block:: console
+    
+    cd ~/assisi
+    git clone https://github.com/assisi/assisipy-examples.git examples
+
+
+Final structure
+---------------
 
 
 After completing all of the abovementioned steps, we should have the following folder structure:
@@ -172,36 +186,6 @@ should also contain sub-directories for ``cppzmq`` and ``zeromq-3.2.4``).
 
 
 
-Installing the Python API -- old version (pre v0.9.0)
------------------------------------------------------
-
-
-.. code-block:: console
-
-  git clone https://github.com/larics/assisi-python python
-  cd python
-  git submodule update --init
-  ./compile_msgs.sh
-  export PYTHONPATH=${PYTHONPATH}:~/assisi/python
-  cd ..
-
-The ``PATH`` and ``PYTHONPATH`` exports have to be done very time you open a new shell, so It's best to add it to the end of your ``~/.bashrc`` file. It's purpose is to enable the importing of the Assisi python API in Python programs.
-
-
-After completing all of the abovementioned steps, we should have the following folder structure:
-  * assisi
-
-    - playground
-    - python
-    - deps
-
-      + zeromq-3.2.4
-      + cppzmq
-      + enki
-
-(Note: for Ubuntu 14.04 installation, ``cppzmq`` and ``zeromq-3.2.4`` use the 
-system installer, and so should not exist in the ``assisi/deps`` directory)
-    
 Running and testing the software
 --------------------------------
 
@@ -214,14 +198,14 @@ To test the software, you will first need to start the simulator:
 
 Take note of the onscreen instructions for manipulating the camera view.
 
-Try running the demos in the ``python/examples`` folder.
+Try running the demos in the ``examples`` folder.
 
 The wandering bee example
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: console
 
-  cd ~/assisi/python/examples/wandering_bee
+  cd ~/assisi/examples/wandering_bee
   ./spawn_bee_in_maze.py
   ./bee_wander.py
   
@@ -233,7 +217,7 @@ If the simulator is running, restart it.
 
 .. code-block:: console
 
-  cd ~/assisi/python/examples/casu_proxy_led
+  cd ~/assisi/examples/casu_proxy_led
   ./spawn_casu_and_bee.py
   ./casu_proxy_led.py
 
@@ -244,7 +228,7 @@ If the simulator is running, restart it.
 
 .. code-block:: console
 
-  cd ~/assisi/python/examples/bees_in_casu_array
+  cd ~/assisi/examples/bees_in_casu_array
   ./spawn_bees_in_casu_array.py
   ./bees_wander.py
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -43,59 +43,10 @@ The next step is `Building the assisi software`_
 Ubuntu 12.04 (Precise) 64-bit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-NOTE: if you are using ubuntu 14.04, skip this section.
+NOTE: we are no longer actively supporting 12.04 installations.  However, in case your platform requires dependencies that cannot be installed via the package manager, we retain the older instructions elsewhere.
 
-Most of the dependencies needed to build and run ASSISI software can
-be installed from official Ubuntu repositories:
+See the guide :ref:`Installation instructions for older distributions`_.
 
-.. code-block:: console
-  
-    sudo apt-get install build-essential git cmake qt4-dev-tools
-    sudo apt-get install libboost-dev libboost-program-options-dev libboost-system-dev
-    sudo apt-get install libboost-filesystem-dev libboost-python-dev
-    sudo apt-get install libprotobuf-dev protobuf-compiler python-protobuf
-    sudo apt-get install python-dev python-sphinx python-yaml
-    sudo apt-get install python-pygraphviz fabric
-
-A few dependencies have to be installed manually. Create a folder for the Assisi project and position yourself there
-
-.. code-block:: console
-    
-    cd ~
-    mkdir assisi
-    cd assisi
-
-Build and install the ZeroMQ networking library:
-
-.. code-block:: console
-
-   mkdir deps
-   cd deps
-   wget http://download.zeromq.org/zeromq-3.2.4.tar.gz
-   tar xvf zeromq-3.2.4.tar.gz
-   cd zeromq-3.2.4
-   ./configure
-   make
-   sudo make install
-   cd ..
-
-After this step you should have the files ``zmq.h`` and ``zmq_utils.h`` in your ``/usr/local/include`` folder.
-
-Add ZeroMQ c++ bindings:
-
-.. code-block:: console
-
-    git clone https://github.com/zeromq/cppzmq
-    sudo cp cppzmq/zmq.hpp /usr/local/include
-
-Now install python-zmq using pip (if you install using apt-get it will install an older version of libzmq as a dependency):
-
-.. code-block:: console
-  
-    sudo apt-get install pip
-    sudo pip install pyzmq
-
-The next step is `Building the assisi software`_ 
 
 MacOS X
 ~~~~~~~

--- a/doc/src/older-platform-install.rst
+++ b/doc/src/older-platform-install.rst
@@ -1,0 +1,58 @@
+Installation instructions for older distributions
+=================================================
+
+Installations on distributions in ubuntu 12.04 are less often used and 
+accordingly latest features are not tested to the same degree.  We 
+retain the full instructions for installation here.
+
+Most of the dependencies needed to build and run ASSISI software can
+be installed from official Ubuntu repositories:
+
+.. code-block:: console
+  
+    sudo apt-get install build-essential git cmake qt4-dev-tools
+    sudo apt-get install libboost-dev libboost-program-options-dev libboost-system-dev
+    sudo apt-get install libboost-filesystem-dev libboost-python-dev
+    sudo apt-get install libprotobuf-dev protobuf-compiler python-protobuf
+    sudo apt-get install python-dev python-sphinx python-yaml
+    sudo apt-get install python-pygraphviz fabric
+
+A few dependencies have to be installed manually. Create a folder for the Assisi project and position yourself there
+
+.. code-block:: console
+    
+    cd ~
+    mkdir assisi
+    cd assisi
+
+Build and install the ZeroMQ networking library:
+
+.. code-block:: console
+
+   mkdir deps
+   cd deps
+   wget http://download.zeromq.org/zeromq-3.2.4.tar.gz
+   tar xvf zeromq-3.2.4.tar.gz
+   cd zeromq-3.2.4
+   ./configure
+   make
+   sudo make install
+   cd ..
+
+After this step you should have the files ``zmq.h`` and ``zmq_utils.h`` in your ``/usr/local/include`` folder.
+
+Add ZeroMQ c++ bindings:
+
+.. code-block:: console
+
+    git clone https://github.com/zeromq/cppzmq
+    sudo cp cppzmq/zmq.hpp /usr/local/include
+
+Now install python-zmq using pip (if you install using apt-get it will install an older version of libzmq as a dependency):
+
+.. code-block:: console
+  
+    sudo apt-get install pip
+    sudo pip install pyzmq
+
+


### PR DESCRIPTION
Installation docs tidied up

- pip now the primary method to install the python API assisi-python
- added instructions for "development mode" installation on a separate page
- 12.04 instructions moved to an archive page
- removed reference to example file (due to the repository split of API and examples)

Issues: cross-references don't seem to build correctly on my local version (using the :ref:`<thingname>`_ directive), but I can't see a problem with the syntax.