### PR TITLE
handle path of the project file correctly

### DIFF
--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -27,7 +27,9 @@ class DataCollector:
         self.dep = {}
 
         self.project_root = os.path.dirname(os.path.abspath(project_file_name))
-        self.data_dir = 'data_' + project_file_name.split('.')[0]
+        self.proj_name = os.path.splitext(os.path.basename(project_file_name))[0]
+        self.data_dir = 'data_' + self.proj_name
+        #self.data_dir = 'data_' + project_file_name.split('.')[0]
 
         self.collected = False
 
@@ -46,7 +48,7 @@ class DataCollector:
         """
         Collect the data to the local machine.
         """
-        
+
         # Create data folder on local machine
         cwd = os.getcwd()
         if cwd != self.project_root:
@@ -59,7 +61,7 @@ class DataCollector:
             # The data directory already exists
             # that's ok
             pass
-       
+
         os.chdir(self.data_dir)
 
         # Download the data from deployment targets
@@ -83,7 +85,7 @@ class DataCollector:
             os.chdir('..')
 
         # Return to the original directory
-        os.chdir(self.project_root)
+        os.chdir(cwd)
 
 
 def main():


### PR DESCRIPTION
- can execute the tool from any location and the data will always be
  collected/pulled into a `data_<projname>` directory, local to the
  project file (`.assisi` file).

closes issue #46 

Given the code structure:
```
base/
    deployment/
        demo.assisi
        <expect data here: data_demo/... >
        sub/
    other/
```

 tested from the following locations:

1. local to the project file
cd base/deployment
collect_data.py demo.assisi

2. a relative path, above
cd base
collect_data.py deployment/demo.assisi

3. relative path, aside
cd base/other
collect_data.py ../deployment/demo.assisi

4. relative path, below
cd base/deployment 

5. does it run with absolute path?
cd /tmp
collect_data.py /tmp/tests/assisipy/base/deployment/demo.assisi

(tests are not fully automated at present; count and size of collected files made manually after each execution, data_demo directory removed before subsequent test.)



