### PR TITLE
collect_data can retrieve results to arbitrary location

### DIFF
--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -9,7 +9,21 @@ import yaml
 from fabric.api import get, run, settings
 
 import argparse
-import os
+import os, errno
+
+def mkdir_p(path):
+    '''
+    recursively create paths, and do not raise error if already exists
+
+    source: http://stackoverflow.com/a/600612
+    '''
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
 class DataCollector:
     """
@@ -29,7 +43,7 @@ class DataCollector:
         self.project_root = os.path.dirname(os.path.abspath(project_file_name))
         self.proj_name = os.path.splitext(os.path.basename(project_file_name))[0]
 
-        if logpath is None:
+        if logpath is None or logpath == 'None':
             self.custom_logpath = False
             self.data_dir = 'data_' + self.proj_name
         else:
@@ -63,8 +77,12 @@ class DataCollector:
         ##if cwd != self.project_root :
             print('Changing directory to {0}'.format(self.project_root))
             os.chdir(self.project_root)
+
+
         try:
-            os.mkdir(self.data_dir)
+            # attempt to create data directory (func is recursive if necessary)
+            mkdir_p(self.data_dir)
+            #os.mkdir(self.data_dir)
             print('Created folder {0}.'.format(self.data_dir))
         except OSError:
             # The data directory already exists
@@ -100,7 +118,7 @@ class DataCollector:
 def main():
     parser = argparse.ArgumentParser(description='Collect CASU logs. Currently assumes that the logs are located in the same folder as the controller.')
     parser.add_argument('project', help='Project file name (.assisi).')
-    parser.add_argument('--logpath', default=None, help="override for log path")
+    parser.add_argument('--logpath', default=None, help="override for path where logs will be written to")
     parser.add_argument('--clean', action='store_true', default=False,
                         help='Remove original log files after copying.')
     args = parser.parse_args()

--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -27,7 +27,9 @@ class DataCollector:
         self.dep = {}
 
         self.project_root = os.path.dirname(os.path.abspath(project_file_name))
-        self.data_dir = 'data_' + project_file_name.split('.')[0]
+        self.proj_name = os.path.splitext(os.path.basename(project_file_name))[0]
+        self.data_dir = 'data_' + self.proj_name
+        #self.data_dir = 'data_' + project_file_name.split('.')[0]
 
         self.collected = False
 
@@ -46,7 +48,7 @@ class DataCollector:
         """
         Collect the data to the local machine.
         """
-        
+
         # Create data folder on local machine
         cwd = os.getcwd()
         if cwd != self.project_root:
@@ -59,7 +61,7 @@ class DataCollector:
             # The data directory already exists
             # that's ok
             pass
-       
+
         os.chdir(self.data_dir)
 
         # Download the data from deployment targets
@@ -83,7 +85,7 @@ class DataCollector:
             os.chdir('..')
 
         # Return to the original directory
-        os.chdir(self.project_root)
+        os.chdir(cwd)
 
 
 def main():

--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -16,7 +16,7 @@ class DataCollector:
     Class for automatically retrieving CASU logs.
     """
 
-    def __init__(self, project_file_name, clean=False):
+    def __init__(self, project_file_name, clean=False, logpath=None):
         """
         Parses the configuration file and initializes internal data structures.
         """
@@ -28,8 +28,16 @@ class DataCollector:
 
         self.project_root = os.path.dirname(os.path.abspath(project_file_name))
         self.proj_name = os.path.splitext(os.path.basename(project_file_name))[0]
-        self.data_dir = 'data_' + self.proj_name
-        #self.data_dir = 'data_' + project_file_name.split('.')[0]
+
+        if logpath is None:
+            self.custom_logpath = False
+            self.data_dir = 'data_' + self.proj_name
+        else:
+            self.custom_logpath = True
+            self.data_dir = os.path.join(
+                os.path.abspath(logpath),
+                'data_' + self.proj_name)
+
 
         self.collected = False
 
@@ -51,7 +59,8 @@ class DataCollector:
 
         # Create data folder on local machine
         cwd = os.getcwd()
-        if cwd != self.project_root:
+        if cwd != self.project_root and not self.custom_logpath:
+        ##if cwd != self.project_root :
             print('Changing directory to {0}'.format(self.project_root))
             os.chdir(self.project_root)
         try:
@@ -91,10 +100,11 @@ class DataCollector:
 def main():
     parser = argparse.ArgumentParser(description='Collect CASU logs. Currently assumes that the logs are located in the same folder as the controller.')
     parser.add_argument('project', help='Project file name (.assisi).')
+    parser.add_argument('--logpath', default=None, help="override for log path")
     parser.add_argument('--clean', action='store_true', default=False,
                         help='Remove original log files after copying.')
     args = parser.parse_args()
-    dc = DataCollector(args.project, args.clean)
+    dc = DataCollector(args.project, args.clean, args.logpath)
     dc.collect()
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes issue #40 

tested with various specified logpaths:
<--logpath not defined> ==> default: pull data local to the .assisi file, <project_path>/data_myproj/
--logpath=/foo/bar  ==> pull data to /foo/bar/data_myproj/
--logpath=baz       ==> pull data to ./baz/data_myproj/
--logpath=None      ==> pull data to <project_path>/data_myproj/

Builds on PR #47 
