### PR TITLE
arbitrary patterns of files can be retrieved.

### DIFF
--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -104,10 +104,15 @@ class DataCollector:
                 with settings(host_string = self.dep[layer][casu]['hostname'],
                               user = self.dep[layer][casu]['user'],
                               warn_only = True):
-                    targetfiles = os.path.join(self.dep[layer][casu]['prefix'], layer, casu, '*.csv')
-                    get(targetfiles,'.')
-                    if self.clean:
-                        run('rm ' + targetfiles)
+                    patterns = (['*.csv',] +
+                            self.dep[layer][casu].get('results', []) )
+
+                    for pattern in patterns:
+                        targetfiles = os.path.join(self.dep[layer][casu]['prefix'],
+                                layer, casu, pattern)
+                        get(targetfiles,'.')
+                        if self.clean:
+                            run('rm ' + targetfiles)
 
             os.chdir('..')
 


### PR DESCRIPTION
closes #41  (issue)

-  *.csv default case, as was behaviour before.
- additional files or patterns can be specified in the .dep file, within
  a "results : ['foo.*', '?.bar', 'fullname']" element.
- tests performed, including *, ?, 'fullname' retrieval, checking the files and sizes
- various different combinations of file type specification and target locations used, including default for each (--logpath=None and results : [] in .dep file, or no results entry in .dep file) all appear ok
