### PR TITLE
added a subdir for results/data retrieved from each CASU

### DIFF
--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -101,6 +101,13 @@ class DataCollector:
                 pass
             os.chdir(layer)
             for casu in self.dep[layer]:
+                try:
+                    os.mkdir(casu)
+                    print('Created folder {0}.'.format(casu))
+                except OSError:
+                    # The directory already exists
+                    pass
+                os.chdir(casu)
                 with settings(host_string = self.dep[layer][casu]['hostname'],
                               user = self.dep[layer][casu]['user'],
                               warn_only = True):
@@ -113,6 +120,8 @@ class DataCollector:
                         get(targetfiles,'.')
                         if self.clean:
                             run('rm ' + targetfiles)
+
+                os.chdir('..')
 
             os.chdir('..')
 


### PR DESCRIPTION
- resolves #59 
- tested with a simple setup that has a non-unique filename for a
  log created by the casus ("calibration.log"), with >1 casu in a
  single layer. Older version clobbers the earlier downloads while
  the new version preserves correctly.

oldver/
└── data_demo
    └── sim-arena1
        ├── 2016-06-03-17-24-51-casu-sim-008.csv
        ├── 2016-06-03-17-24-51-casu-sim-009.csv
        └── calibration.log

newver/
└── data_demo
    └── sim-arena1
        ├── casu-sim-008
        │   ├── 2016-06-03-17-24-51-casu-sim-008.csv
        │   └── calibration.log
        └── casu-sim-009
            ├── 2016-06-03-17-24-51-casu-sim-009.csv
            └── calibration.log