### PR TITLE
VERSION file removed from git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ nosetests.xml
 # Generated message files
 #assisipy/msg/*pb2.py
 
+# Generated package info
+VERSION
+
 # Doc output folder
 doc/latex
 doc/html

--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,0 @@
-
-======================================================================
-This release was sourced from:
-	assisi-python git rev 76a0dad028072807e39b207de9406159d3485256
-	assisi-msg    git rev ed6c974cbd47b3d24386c7bb3acf20ac2459c41b
-	assisi-python package version 0.12.0
-======================================================================

--- a/create_package.sh
+++ b/create_package.sh
@@ -9,15 +9,9 @@ assisipy_rev=`git rev-parse HEAD`
 assisi_msg_rev=`cd msg && git rev-parse HEAD`
 assisipy_ver=`python -c "import assisipy; print assisipy.__version__"`
 
-# but first, ensure we are working with the repo version
 VERSIONFILE=VERSION
-#VERSIONFILE=/dev/null
-if [ -f "${VERSIONFILE}" ] ; then
-    git checkout -- ${VERSIONFILE}
-else
-    echo "[I] skipping cleanup"
-fi
 
+# write all the revisions/version numbers to file and to screen (via tee)
 printf "\n" | tee ${VERSIONFILE}
 printf "======================================================================\n" | tee -a ${VERSIONFILE}
 printf "This release was sourced from:\n"               | tee -a ${VERSIONFILE}


### PR DESCRIPTION
- VERSION file is autogenerated so we do not track it
  ==> added to .gitignore
  ==> removed from tracking
  ==> minor mod to create_package to remove interacting with repo
      regarding this file.
- closes #64