### PR TITLE
moved fabfile to the deployment sandbox

### DIFF
--- a/assisipy/assisirun.py
+++ b/assisipy/assisirun.py
@@ -26,7 +26,8 @@ class AssisiRun:
 
         self.proj_name = os.path.splitext(os.path.basename(project_name))[0]
         self.project_root = os.path.dirname(os.path.abspath(project_name))
-        self.fabfile_name = self.proj_name + '.py'
+        self.sandbox_dir = self.proj_name + '_sandbox'
+        self.fabfile_name = os.path.join(self.sandbox_dir, self.proj_name + '.py')
         self.depspec = {}
         with open(project_name) as project:
             project_spec = yaml.safe_load(project)

--- a/assisipy/deploy.py
+++ b/assisipy/deploy.py
@@ -22,14 +22,14 @@ class Deploy:
         Parses the configuration files and initializes internal data structures.
         """
         self.proj_name = os.path.splitext(os.path.basename(project_file_name))[0]
-        self.fabfile_name = self.proj_name + '.py'
-        #self.fabfile_name = project_file_name[:-7] + '.py'
+        self.project_root = os.path.dirname(os.path.abspath(project_file_name))
+        self.sandbox_dir = self.proj_name + '_sandbox'
+        self.fabfile_name = os.path.join(self.sandbox_dir, self.proj_name + '.py')
+
         self.arena = {}
         self.nbg = None
         self.dep = {}
 
-        self.project_root = os.path.dirname(os.path.abspath(project_file_name))
-        self.sandbox_dir = self.proj_name + '_sandbox'
 
         self.prepared = False
 


### PR DESCRIPTION
- deploy.Deploy.prepare generates the fabfile in the sandbox
- assisirun.init expects to find the file in sandbox
- tested with simulation runs, no problems observed (collect_data.py and
  sim.py are not affected).

- goes towards solving issue #32 but not completely, until the sandbox
  is relocatable by a command-line option. (or a cleanup tool)
  - maybe the option "working directory"/"output-dir" could be stored in the 
    `.assisi` project file, so that all tools have access to one data value