### PR TITLE
Crypto warnings arising from use o fab are suppressed 

### DIFF
--- a/assisipy/collect_data.py
+++ b/assisipy/collect_data.py
@@ -7,7 +7,7 @@ Tool for collecting data logged by CASUs after an experiment.
 
 import yaml
 from fabric.api import get, run, settings
-
+import warnings
 import argparse
 import os, errno
 
@@ -152,7 +152,10 @@ def main():
                         help='Name of single layer to collect data for')
     args = parser.parse_args()
     dc = DataCollector(args.project, args.clean, args.logpath)
-    dc.collect(args.layer)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action="ignore", category=FutureWarning, module="Crypto", lineno=141)
+        dc.collect(args.layer)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- the single FutureWarning is ignored in all the contexts where it is
  produced (during the deploy transfer, during the assisirun -- but in
  the code generated within deploy prepare, and during collect_data)

- the warning is selected by type, package, and line number, so no other
  warnings are erroneously hidden

- also added discussion notes in deploy.py for future reference.

- closes #95

